### PR TITLE
Fix parameter handling in API routes

### DIFF
--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -6,10 +6,10 @@ const prisma = new PrismaClient();
 // GET - Buscar contato por ID
 export async function GET(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const contact = await prisma.contact.findUnique({
             where: { id },
             include: {
@@ -40,10 +40,10 @@ export async function GET(
 // PUT - Atualizar contato
 export async function PUT(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const body = await request.json();
 
         const {
@@ -125,10 +125,10 @@ export async function PUT(
 // DELETE - Deletar contato
 export async function DELETE(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
 
         // Verificar se o contato existe
         const existingContact = await prisma.contact.findUnique({

--- a/src/app/api/mailing-lists/[id]/route.ts
+++ b/src/app/api/mailing-lists/[id]/route.ts
@@ -5,10 +5,10 @@ const prisma = new PrismaClient();
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
 
         const mailingList = await prisma.mailingList.findUnique({
             where: { id },
@@ -48,10 +48,10 @@ export async function GET(
 
 export async function PUT(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const body = await request.json();
         const { name, description, color } = body;
 
@@ -120,10 +120,10 @@ export async function PUT(
 
 export async function DELETE(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
 
         // Verificar se a lista existe
         const existingList = await prisma.mailingList.findUnique({

--- a/src/app/api/scripts/[id]/route.ts
+++ b/src/app/api/scripts/[id]/route.ts
@@ -3,10 +3,10 @@ import { PrismaClient } from '@/generated/prisma';
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const prisma = new PrismaClient();
 
         const script = await prisma.emailScript.findUnique({
@@ -62,10 +62,10 @@ export async function GET(
 
 export async function PUT(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const prisma = new PrismaClient();
         const body = await request.json();
 
@@ -126,10 +126,10 @@ export async function PUT(
 
 export async function DELETE(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const prisma = new PrismaClient();
 
         // Verificar se o script existe

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -5,10 +5,10 @@ const prisma = new PrismaClient();
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const template = await prisma.emailTemplate.findUnique({
             where: { id },
         });
@@ -32,10 +32,10 @@ export async function GET(
 
 export async function PUT(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
         const body = await request.json();
 
         const {
@@ -79,10 +79,10 @@ export async function PUT(
 
 export async function DELETE(
     request: NextRequest,
-    { params }: { params: Promise<{ id: string }> }
+    { params }: { params: { id: string } }
 ) {
     try {
-        const { id } = await params;
+        const { id } = params;
 
         // Verificar se o template existe
         const existingTemplate = await prisma.emailTemplate.findUnique({

--- a/src/app/api/track/click/[trackingId]/route.ts
+++ b/src/app/api/track/click/[trackingId]/route.ts
@@ -5,10 +5,10 @@ import { isValidEmailClient, isValidReferrer, getNextStatus, validateTrackingTok
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: Promise<{ trackingId: string }> }
+    { params }: { params: { trackingId: string } }
 ) {
     try {
-        const { trackingId } = await params;
+        const { trackingId } = params;
         const { searchParams } = new URL(request.url);
         const originalUrl = searchParams.get('url');
         const token = searchParams.get('t');

--- a/src/app/api/track/open/[trackingId]/route.ts
+++ b/src/app/api/track/open/[trackingId]/route.ts
@@ -5,10 +5,10 @@ import { isValidEmailClient, isValidReferrer, getNextStatus, validateTrackingTok
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: Promise<{ trackingId: string }> }
+    { params }: { params: { trackingId: string } }
 ) {
     try {
-        const { trackingId } = await params;
+        const { trackingId } = params;
         const { searchParams } = new URL(request.url);
         const token = searchParams.get('t');
 
@@ -96,7 +96,7 @@ export async function GET(
     } catch (error) {
         console.error('❌ ERROR in tracking:', error);
         // Sempre retornar pixel mesmo em caso de erro
-        const { trackingId } = await params;
+        const { trackingId } = params;
         return getOptimizedTrackingPixelResponse(trackingId);
     }
 }


### PR DESCRIPTION
## Summary
- correct route parameter types across API endpoints

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module `@/generated/prisma`)*

------
https://chatgpt.com/codex/tasks/task_e_6840500e89208323a8b73eb6dc1bf59e